### PR TITLE
removing trailing whitespace to make git happy

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -1,13 +1,13 @@
 = Mobile Fu
 
-Want to automatically detect mobile devices that access your Rails application?  
+Want to automatically detect mobile devices that access your Rails application?
 Mobile Fu allows you to do just that.  People can access your site from a Palm,
 Blackberry, iPhone, iPad, Nokia, etc. and it will automatically adjust the format
-of the request from :html to :mobile.  
+of the request from :html to :mobile.
 
 == Rails 3 Compatibility
 
-The master branch of this plugin is Rails 3 compatible.  
+The master branch of this plugin is Rails 3 compatible.
 
 To use the Rails 3 compatible version of this plugin, please install it like so:
 
@@ -29,7 +29,7 @@ Add this this one line to the controller.
       has_mobile_fu
     end
 
-Once this is in place, any request that comes from a mobile device will be be 
+Once this is in place, any request that comes from a mobile device will be be
 set as :mobile format.  It is up to you to determine how you want to handle
 these requests.  It is also up to you to create the .mobile.erb versions of
 your views that are to be requested.
@@ -59,7 +59,7 @@ baked in to Mobile Fu.
 
 If you are including a css or sass file via stylesheet_link_tag, all you have
 to do is add _device to the name of one of your files to override your styling
-for a certain device.  The stylesheet that is loaded is dependant on which device 
+for a certain device.  The stylesheet that is loaded is dependant on which device
 is making the request.
 
   e.g., Accessing a page from a Blackberry.
@@ -87,12 +87,12 @@ http://blogs.pathf.com/agileajax/2008/05/rails-developme.html
 Hopefully this should help you create some awesome mobile applications.
 
 == Testing Mobile Interface
-	
-If you want to force the mobile interface for testing, you can either use a 
-mobile device emulator, or you can pass 'true' to has_mobile_fu. 
+
+If you want to force the mobile interface for testing, you can either use a
+mobile device emulator, or you can pass 'true' to has_mobile_fu.
 
   class ApplicationController < ActionController::Base
-    has_mobile_fu(true) 
+    has_mobile_fu(true)
   end
 
 

--- a/lib/mobile_fu.rb
+++ b/lib/mobile_fu.rb
@@ -8,29 +8,29 @@ module ActionController
                           'pdxgw|netfront|xiino|vodafone|portalmmm|sagem|mot-|sie-|ipod|up\\.b|' +
                           'webos|amoi|novarra|cdm|alcatel|pocket|ipad|iphone|mobileexplorer|' +
                           'mobile'
-    
+
     def self.included(base)
       base.extend(ClassMethods)
     end
-    
+
     module ClassMethods
-      
-      # Add this to one of your controllers to use MobileFu.  
+
+      # Add this to one of your controllers to use MobileFu.
       #
-      #    class ApplicationController < ActionController::Base 
+      #    class ApplicationController < ActionController::Base
       #      has_mobile_fu
       #    end
       #
       # You can also force mobile mode by passing in 'true'
       #
-      #    class ApplicationController < ActionController::Base 
+      #    class ApplicationController < ActionController::Base
       #      has_mobile_fu(true)
       #    end
-        
+
       def has_mobile_fu(test_mode = false)
         include ActionController::MobileFu::InstanceMethods
 
-        if test_mode 
+        if test_mode
           before_filter :force_mobile_format
         else
           before_filter :set_mobile_format
@@ -40,7 +40,7 @@ module ActionController
         helper_method :in_mobile_view?
         helper_method :is_device?
       end
-      
+
       def is_mobile_device?
         @@is_mobile_device
       end
@@ -53,50 +53,50 @@ module ActionController
         @@is_device
       end
     end
-    
+
     module InstanceMethods
-      
+
       # Forces the request format to be :mobile
-      
+
       def force_mobile_format
         request.format = :mobile
         session[:mobile_view] = true if session[:mobile_view].nil?
       end
-      
+
       # Determines the request format based on whether the device is mobile or if
       # the user has opted to use either the 'Standard' view or 'Mobile' view.
-      
+
       def set_mobile_format
         if is_mobile_device? && !request.xhr?
           request.format = session[:mobile_view] == false ? :html : :mobile
           session[:mobile_view] = true if session[:mobile_view].nil?
         end
       end
-      
+
       # Returns either true or false depending on whether or not the format of the
       # request is either :mobile or not.
-      
+
       def in_mobile_view?
         request.format.to_sym == :mobile
       end
-      
+
       # Returns either true or false depending on whether or not the user agent of
       # the device making the request is matched to a device in our regex.
-      
+
       def is_mobile_device?
         request.user_agent.to_s.downcase =~ Regexp.new(ActionController::MobileFu::MOBILE_USER_AGENTS)
       end
 
       # Can check for a specific user agent
       # e.g., is_device?('iphone') or is_device?('mobileexplorer')
-      
+
       def is_device?(type)
         request.user_agent.to_s.downcase.include?(type.to_s.downcase)
       end
     end
-    
+
   end
-  
+
 end
 
 ActionController::Base.send(:include, ActionController::MobileFu)

--- a/lib/mobile_fu_helper.rb
+++ b/lib/mobile_fu_helper.rb
@@ -1,10 +1,10 @@
 module MobileFuHelper
   ACCEPTABLE_TYPES = [:mobile, :basic]
-  
+
   def mobile_xhtml_doctype(type = :mobile, version = '1.0')
     raise Exception.new("MobileFu: XHTML DOCTYPE type must either be ':mobile' or ':basic'") unless ACCEPTABLE_TYPES.include?(type)
     raise Exception.new("MobileFu: XHTML DOCTYPE version must be in the format of '1.0' or '1.1', etc.") unless version.include?('.')
-    
+
     doc_type = "<?xml version=\"1.0\" charset=\"UTF-8\" ?>\n"
     doc_type += "<!DOCTYPE html PUBLIC "
     doc_type += case type
@@ -15,7 +15,7 @@ module MobileFuHelper
                 end
     doc_type
   end
-  
+
   def js_enabled_mobile_device?
     is_device?('iphone') || is_device?('ipod') || is_device?('ipad') || is_device?('mobileexplorer') || is_device?('android')
   end

--- a/lib/mobilized_styles.rb
+++ b/lib/mobilized_styles.rb
@@ -1,5 +1,5 @@
 # Copyright (c) 2008 Brendan G. Lim (brendan@intridea.com)
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
 # "Software"), to deal in the Software without restriction, including
@@ -7,10 +7,10 @@
 # distribute, sublicense, and/or sell copies of the Software, and to
 # permit persons to whom the Software is furnished to do so, subject to
 # the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be
 # included in all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 # EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 # MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -20,10 +20,10 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 module MobilizedStyles
-  
+
   # This logic was taken from Michael Bleigh's browserized styles
   # with modification to work for mobile browsers.
-  
+
   def user_agent_device_name
     @user_agent_device_name ||= begin
 
@@ -33,7 +33,7 @@ module MobilizedStyles
 
       if ua.index('mobileexplorer') || ua.index('windows ce')
         'mobileexplorer'
-      elsif ua.index('blackberry') 
+      elsif ua.index('blackberry')
         'blackberry'
       elsif ua.index('iphone') || ua.index('ipod')
         'iphone'
@@ -41,9 +41,9 @@ module MobilizedStyles
         'ipad'
       elsif ua.index('android')
         'android'
-      elsif ua.index('nokia') 
+      elsif ua.index('nokia')
         'nokia'
-      elsif ua.index('palm') 
+      elsif ua.index('palm')
         'palm'
       end
     end

--- a/spec/mobilized_styles_spec.rb
+++ b/spec/mobilized_styles_spec.rb
@@ -10,7 +10,6 @@ module ActionView
 end
 
 describe MobilizedStyles do
-  
   before(:each) do
     @view = mock(:ActionView)
     @request = mock(:ActionRequest)
@@ -18,18 +17,18 @@ describe MobilizedStyles do
     @view.stub!(:request).and_return(@request)
     @request.stub!(:user_agent)
   end
-  
+
   def ua(str)
     @request.stub!(:user_agent).and_return(str)
   end
-  
+
   it "will include a mobilized css file if it recognizes a string in the user agent" do
     ua "iphone"
     File.should_receive(:exist?).with("stylesheets/style_iphone.css").and_return(true)
     @view.should_receive(:stylesheet_link_tag_without_mobilization).with("style", "style_iphone")
     @view.stylesheet_link_tag_with_mobilization("style")
   end
-  
+
   it "includes mobiziled css files whether or not the original call to stylesheet_link_tag used a file extension" do
     ua "blackberry"
     File.should_receive(:exist?).with("stylesheets/style_blackberry.css").and_return(true)


### PR DESCRIPTION
When you vendor the mobile-fu plugin in a Rails app using a common git whitespace setting, you'll get this message from git:

Applying: installed mobile-fu plugin
*
- You have some suspicious patch lines:

With a long list of mobile-fu lines. It won't let you commit without using the --no-verify flag, but it's a pain and I still haven't found a solution for when I git rebase origin/master from a topic branch when master has the mobile-fu commit.

This commit just removes that trailing whitespace to make git happy.
