### PR TITLE
force_mobile_format

### DIFF
--- a/lib/mobile_fu.rb
+++ b/lib/mobile_fu.rb
@@ -59,8 +59,10 @@ module ActionController
       # Forces the request format to be :mobile
       
       def force_mobile_format
-        request.format = :mobile
-        session[:mobile_view] = true if session[:mobile_view].nil?
+        if !request.xhr?
+          request.format = :mobile
+          session[:mobile_view] = true if session[:mobile_view].nil?
+        end
       end
       
       # Determines the request format based on whether the device is mobile or if


### PR DESCRIPTION
I noticed that when testing my mobile interface, my AJAX requests were failing.

It turned out that force_mobile_format was forcing those requests to be interpreted as :mobile, and that meant my action, which looked like below, couldn't work properly

```
  format.any(:html, :mobile)
  format.js {
    dataset = @datasets.find { |d| dataset_cache_key(d) == params[:key] }
    raise unless dataset
    render :partial => "datasets/dataset_output", :locals => {:dataset => dataset}
  }
```

I guess the intention of force_mobile_format is to work identically to set_mobile_format, except that it doesn't care whether the UA is a mobile device or not. So, my patch represents that :)

Let me know if you agree :)
