### PR TITLE
allow the mobile format to be configured.

### DIFF
--- a/lib/mobile_fu.rb
+++ b/lib/mobile_fu.rb
@@ -27,7 +27,12 @@ module ActionController
       #      has_mobile_fu(true)
       #    end
         
-      def has_mobile_fu(test_mode = false)
+      #def has_mobile_fu(test_mode = false)
+      def has_mobile_fu(*args)
+        options = args.extract_options!.to_options!
+        test_mode = args.shift || options[:test]
+        format = options[:format] || :mobile
+
         include ActionController::MobileFu::InstanceMethods
 
         if test_mode 
@@ -35,6 +40,8 @@ module ActionController
         else
           before_filter :set_mobile_format
         end
+
+        mobile_format(format)
 
         helper_method :is_mobile_device?
         helper_method :in_mobile_view?

--- a/lib/mobile_fu.rb
+++ b/lib/mobile_fu.rb
@@ -52,15 +52,29 @@ module ActionController
       def is_device?(type)
         @@is_device
       end
+
+      def mobile_format(*value)
+        @@mobile_format = value.shift.to_s.to_sym unless value.blank?
+        @@mobile_format ||= :mobile
+      end
+
+      def mobile_format=(value)
+        mobile_format(value)
+      end
     end
     
     module InstanceMethods
-      
-      # Forces the request format to be :mobile
+
+      # Forces the request format to be mobile_format
       
       def force_mobile_format
-        request.format = :mobile
+        request.format = mobile_format
         session[:mobile_view] = true if session[:mobile_view].nil?
+      end
+
+      # Returns the configured mobile_format - :mobile by default
+      def mobile_format
+        self.class.mobile_format
       end
       
       # Determines the request format based on whether the device is mobile or if
@@ -68,7 +82,7 @@ module ActionController
       
       def set_mobile_format
         if is_mobile_device? && !request.xhr?
-          request.format = session[:mobile_view] == false ? :html : :mobile
+          request.format = session[:mobile_view] == false ? :html : mobile_format
           session[:mobile_view] = true if session[:mobile_view].nil?
         end
       end


### PR DESCRIPTION
our application is cleanly partitioned under /m so we use the code, but specifiying the format is very useful.
