### PR TITLE
Allow :only, :except, etc to be passed to has_mobile_fu

### DIFF
--- a/lib/mobile_fu.rb
+++ b/lib/mobile_fu.rb
@@ -37,9 +37,9 @@ module ActionController
         include ActionController::MobileFu::InstanceMethods
 
         if options.respond_to?(:delete) && options.delete( :test_mode ) || options === true
-          before_filter :force_mobile_format
+          before_filter :force_mobile_format, options
         else
-          before_filter :set_mobile_format
+          before_filter :set_mobile_format, options
         end
 
         helper_method :is_mobile_device?

--- a/lib/mobile_fu.rb
+++ b/lib/mobile_fu.rb
@@ -36,7 +36,7 @@ module ActionController
       def has_mobile_fu(options = {})
         include ActionController::MobileFu::InstanceMethods
 
-        if options.responds_to?(:delete) && options.delete( :test_mode )
+        if options.respond_to?(:delete) && options.delete( :test_mode )
           before_filter :force_mobile_format
         else
           before_filter :set_mobile_format

--- a/lib/mobile_fu.rb
+++ b/lib/mobile_fu.rb
@@ -21,16 +21,22 @@ module ActionController
       #      has_mobile_fu
       #    end
       #
-      # You can also force mobile mode by passing in 'true'
+      # You can also pass any of the options available to before_filter (:only, :exclude)
+      #
+      #    class WelcomeController < ActionController::Base 
+      #      has_mobile_fu :only => :index
+      #    end
+      #
+      # You can also force mobile mode by passing in 'true' or :test_mode => true
       #
       #    class ApplicationController < ActionController::Base 
       #      has_mobile_fu(true)
       #    end
         
-      def has_mobile_fu(test_mode = false)
+      def has_mobile_fu(options = {})
         include ActionController::MobileFu::InstanceMethods
 
-        if test_mode 
+        if options.responds_to?(:delete) && options.delete( :test_mode )
           before_filter :force_mobile_format
         else
           before_filter :set_mobile_format

--- a/lib/mobile_fu.rb
+++ b/lib/mobile_fu.rb
@@ -36,7 +36,7 @@ module ActionController
       def has_mobile_fu(options = {})
         include ActionController::MobileFu::InstanceMethods
 
-        if options.respond_to?(:delete) && options.delete( :test_mode ) || options
+        if options.respond_to?(:delete) && options.delete( :test_mode ) || options === true
           before_filter :force_mobile_format
         else
           before_filter :set_mobile_format

--- a/lib/mobile_fu.rb
+++ b/lib/mobile_fu.rb
@@ -36,7 +36,7 @@ module ActionController
       def has_mobile_fu(options = {})
         include ActionController::MobileFu::InstanceMethods
 
-        if options.respond_to?(:delete) && options.delete( :test_mode )
+        if options.respond_to?(:delete) && options.delete( :test_mode ) || options
           before_filter :force_mobile_format
         else
           before_filter :set_mobile_format


### PR DESCRIPTION
Pass along options has to before_filter in has_mobile_fu, taking into account that the has could be boolean true.
