### PR TITLE
Added Maemo and Fennec to detected mobile browsers

### DIFF
--- a/lib/mobile_fu.rb
+++ b/lib/mobile_fu.rb
@@ -7,7 +7,7 @@ module ActionController
                           'x320|x240|j2me|sgh|portable|sprint|docomo|kddi|softbank|android|mmp|' +
                           'pdxgw|netfront|xiino|vodafone|portalmmm|sagem|mot-|sie-|ipod|up\\.b|' +
                           'webos|amoi|novarra|cdm|alcatel|pocket|ipad|iphone|mobileexplorer|' +
-                          'mobile'
+                          'mobile|maemo|fennec'
     
     def self.included(base)
       base.extend(ClassMethods)

--- a/lib/mobile_fu.rb
+++ b/lib/mobile_fu.rb
@@ -7,7 +7,7 @@ module ActionController
                           'x320|x240|j2me|sgh|portable|sprint|docomo|kddi|softbank|android|mmp|' +
                           'pdxgw|netfront|xiino|vodafone|portalmmm|sagem|mot-|sie-|ipod|up\\.b|' +
                           'webos|amoi|novarra|cdm|alcatel|pocket|ipad|iphone|mobileexplorer|' +
-                          'mobile|maemo|fennec'
+                          'mobile'
     
     def self.included(base)
       base.extend(ClassMethods)


### PR DESCRIPTION
Hi,

Please could you merge this change to add Maemo and Fennec to detected mobile browsers? Maemo is the Linux mobile operating system by Nokia and Fennec is the code name for Mozillas mobile version of Firefox (at least on old builds still circulating within the community). I have checked all related applications and adding neither should harm any desktop browsers.

I am doing this pull request on behalf of the Diaspora\* community where many users have complained the lack of mobile support for the N900 which is Maemo based and also has stable Fennec builds in popular use. Diaspora\* uses mobile-fu as the library for determining what browsers are on mobile devices.

As Diaspora\* is currently going to a critical beta launch I am wondering if at all possible you could merge asap and cut a new gem to RubyGems? We would be very grateful.

If you want more information about Diaspora*, please check here: http://diasporafoundation.org/
And if you would like an invite to the official pod, I can supply one :)

Thanks!

Br,
Jason
