### PR TITLE
added support for ignored_formats

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -94,21 +94,22 @@ Hopefully this should help you create some awesome mobile applications.
 
 == Ignoring specific request formats
 
-If you want to ignore specific request formats you can just pass ':ignore_formats => [<array of your formats>]' to has_mobile_fu.
+If you want to ignore specific request formats you can just pass ':ignore_formats => [<array of your formats>]' as second argument to has_mobile_fu.
+NOTE: If you want to pass :ignore_formats you'll have to pass the 1st argument (test_mode). If you don't know what to put in just pass "false".
 
 example:
   class ApplicationController < ActionController::Base
-    has_mobile_fu :ignore_formats => [:iphone, :json] 
+    has_mobile_fu false, :ignore_formats => [:iphone, :json] 
   end
 
 == Testing Mobile Interface
 	
 If you want to force the mobile interface for testing, you can either use a 
-mobile device emulator, or you can pass ':test_mode => true' to has_mobile_fu. 
+mobile device emulator, or you can pass 'true' as first argument to has_mobile_fu. 
 
 example:
   class ApplicationController < ActionController::Base
-    has_mobile_fu :test_mode => true 
+    has_mobile_fu true 
   end
 
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -1,5 +1,11 @@
 = Mobile Fu
 
+
+This fork adds the ability to ignore curtain request formats from being mobilized. You might want to return JSON for :json or :iphone mime types and not let mobile_fu convert your format to :mobile.
+
+Usage example at the end of this file.
+
+
 Want to automatically detect mobile devices that access your Rails application?  
 Mobile Fu allows you to do just that.  People can access your site from a Palm,
 Blackberry, iPhone, iPad, Nokia, etc. and it will automatically adjust the format
@@ -86,13 +92,23 @@ http://blogs.pathf.com/agileajax/2008/05/rails-developme.html
 
 Hopefully this should help you create some awesome mobile applications.
 
+== Ignoring specific request formats
+
+If you want to ignore specific request formats you can just pass ':ignore_formats => [<array of your formats>]' to has_mobile_fu.
+
+example:
+  class ApplicationController < ActionController::Base
+    has_mobile_fu :ignore_formats => [:iphone, :json] 
+  end
+
 == Testing Mobile Interface
 	
 If you want to force the mobile interface for testing, you can either use a 
-mobile device emulator, or you can pass 'true' to has_mobile_fu. 
+mobile device emulator, or you can pass ':test_mode => true' to has_mobile_fu. 
 
+example:
   class ApplicationController < ActionController::Base
-    has_mobile_fu(true) 
+    has_mobile_fu :test_mode => true 
   end
 
 

--- a/lib/mobile_fu.rb
+++ b/lib/mobile_fu.rb
@@ -29,11 +29,10 @@ module ActionController
 
       def ignored_formats; @@ignored_formats; end
 
-      def has_mobile_fu(options = {})
+      def has_mobile_fu(test_mode = false, *args)
         include ActionController::MobileFu::InstanceMethods
 
-        @@ignored_formats = options.has_key?(:ignore_formats) ? options[:ignore_formats] : []
-        test_mode = options.has_key?(:test_mode) ? options[:test_mode] : false
+        @@ignored_formats = args.has_key?(:ignore_formats) ? args[:ignore_formats] : []
 
         if test_mode
           before_filter :force_mobile_format

--- a/lib/mobile_fu.rb
+++ b/lib/mobile_fu.rb
@@ -29,10 +29,10 @@ module ActionController
 
       def ignored_formats; @@ignored_formats; end
 
-      def has_mobile_fu(test_mode = false, *args)
+      def has_mobile_fu(test_mode = false, options)
         include ActionController::MobileFu::InstanceMethods
 
-        @@ignored_formats = args.has_key?(:ignore_formats) ? args[:ignore_formats] : []
+        @@ignored_formats = options.has_key?(:ignore_formats) ? options[:ignore_formats] : []
 
         if test_mode
           before_filter :force_mobile_format


### PR DESCRIPTION
This fork adds the ability to ignore curtain request formats from being mobilized. You might want to return JSON for :json or :iphone mime types and not let mobile_fu convert your format to :mobile.

Usage example at the end of README.rdoc file.
