### PR TITLE
Fix to leave alone JSON (or other non-HTML) requests

### DIFF
--- a/lib/mobile_fu.rb
+++ b/lib/mobile_fu.rb
@@ -69,7 +69,7 @@ module ActionController
       # the user has opted to use either the 'Standard' view or 'Mobile' view.
 
       def set_mobile_format
-        if is_mobile_device? && !request.xhr?
+        if request.format.html? && is_mobile_device? && !request.xhr?
           request.format = session[:mobile_view] == false ? :html : :mobile
           session[:mobile_view] = true if session[:mobile_view].nil?
         end


### PR DESCRIPTION
There are applications that handle mobile web clients just as well as API or file (think CSV) requests from mobile devices. That's usually not a problem until the project name contains the "mobi" character sequence, which gets propagated to the User-Agent header, making mobile-fu turn all the non-HTML requests to mobile HTML ones, most possibly leading to a "view not found" error.

Considering that a lot of mobile projects will indeed have the word "mobile" in their name somehow, this fix can be pretty important.
